### PR TITLE
Changed the download functionality to cover IE.

### DIFF
--- a/gateway/assets/script/bootstrap.js
+++ b/gateway/assets/script/bootstrap.js
@@ -87,40 +87,22 @@ app.controller("home", ['$scope', '$log', '$http', '$location', '$interval', '$f
 
             var tryDownload = function(data, filename) {
                 var caught;
-
-                var linkElement = document.createElement('a');
+            
                 try {
                     var blob = new Blob([data], { type: "binary/octet-stream" });
-                    var url = window.URL.createObjectURL(blob);
-
-                    linkElement.setAttribute('href', url);
-                    linkElement.setAttribute("download", filename);
-         
-                    var clickEvent;
-
-                    if((navigator.userAgent.indexOf("MSIE") != -1 ) || (!!document.documentMode == true )) { // for IE 11
-                        clickEvent = document.createEvent("MouseEvent");
-
-                        clickEvent.initMouseEvent("click",  /* eventName */
-                                            true,           /* bubbles */
-                                            false,          /* cancelable */
-                                            window,         /* view */
-                                            0,0,0,0,0,      /* detail, screenX, screenY, clientX, clientY */
-                                            false,          /* ctrlKey */
-                                            false,          /* altKey */
-                                            false,          /* shiftKey */
-                                            false,          /* metaKey */
-                                            0,              /* button */
-                                            null            /* relatedTarget */
-                                        );
-                    } else {
-                        clickEvent = new MouseEvent("click", {
-                            "view": window,
-                            "bubbles": true,
-                            "cancelable": false
-                        });
+            
+                    if (window.navigator.msSaveBlob) { // // IE hack; see http://msdn.microsoft.com/en-us/library/ie/hh779016.aspx
+                        window.navigator.msSaveOrOpenBlob(blob, filename);
                     }
-                    linkElement.dispatchEvent(clickEvent);
+                    else {
+                        var linkElement = window.document.createElement("a");
+                        linkElement.href = window.URL.createObjectURL(blob);
+                        linkElement.download = filename;
+                        document.body.appendChild(linkElement);
+                        linkElement.click();
+                        document.body.removeChild(linkElement);
+                    }
+            
                 } catch (ex) {
                     caught = ex;
                 }


### PR DESCRIPTION
Signed-off-by: Ken Fukuyama <kenfdev@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Since IE doesn't work well with `.click()` (because of access denied) we
can take advantage of the `navigator.msSaveOrOpenBlob`.
https://stackoverflow.com/questions/46232980/click-giving-access-denied-in-ie11/46233123#46233123
